### PR TITLE
Configure dataloader

### DIFF
--- a/lib/dx.ex
+++ b/lib/dx.ex
@@ -100,6 +100,7 @@ defmodule Dx do
     case fun.(eval) do
       {:not_loaded, data_reqs} -> Eval.load_data_reqs(eval, data_reqs) |> load_all_data_reqs(fun)
       {:ok, result, _binds} -> {:ok, result, eval.cache}
+      {:error, :timeout} -> {:error, %Dx.Error.Timeout{configured_timeout: eval.loader_options[:timeout]}}
       other -> other
     end
   end

--- a/lib/dx.ex
+++ b/lib/dx.ex
@@ -34,7 +34,10 @@ defmodule Dx do
   - **return_cache** (boolean) makes non-bang functions return `{:ok, result, cache}` instead of
     `{:ok, result}` on success. This `cache` can be passed to other Dx functions (see `cache` option)
   - **cache** (`Dataloader` struct) can be used to pass in an existing cache, so data already loaded
-    doesn't need to be loaded again. Can be initialized using `Loaders.Dataloader.init/0`.
+    doesn't need to be loaded again. Can be initialized using `Dx.Loaders.Dataloader.init/0`.
+  - **loader** allows choosing a loader module. Defaults to `Dx.Loaders.Dataloader`.
+  - **loader_options** are passed to `loader.init/1` function. See `Dx.Loaders.Dataloader` for options
+    supported by the default loader.
   """
 
   alias Dx.{Engine, Result, Util}

--- a/lib/dx.ex
+++ b/lib/dx.ex
@@ -34,7 +34,7 @@ defmodule Dx do
   - **return_cache** (boolean) makes non-bang functions return `{:ok, result, cache}` instead of
     `{:ok, result}` on success. This `cache` can be passed to other Dx functions (see `cache` option)
   - **cache** (`Dataloader` struct) can be used to pass in an existing cache, so data already loaded
-    doesn't need to be loaded again. Can be initialized using `Dx.Loaders.Dataloader.init/0`.
+    doesn't need to be loaded again. Can be initialized using `Dx.Loaders.Dataloader.init/1`.
   - **loader** allows choosing a loader module. Defaults to `Dx.Loaders.Dataloader`.
   - **loader_options** are passed to `loader.init/1` function. See `Dx.Loaders.Dataloader` for options
     supported by the default loader.

--- a/lib/dx.ex
+++ b/lib/dx.ex
@@ -98,10 +98,17 @@ defmodule Dx do
 
   defp load_all_data_reqs(eval, fun) do
     case fun.(eval) do
-      {:not_loaded, data_reqs} -> Eval.load_data_reqs(eval, data_reqs) |> load_all_data_reqs(fun)
-      {:ok, result, _binds} -> {:ok, result, eval.cache}
-      {:error, :timeout} -> {:error, %Dx.Error.Timeout{configured_timeout: eval.loader_options[:timeout]}}
-      other -> other
+      {:not_loaded, data_reqs} ->
+        Eval.load_data_reqs(eval, data_reqs) |> load_all_data_reqs(fun)
+
+      {:ok, result, _binds} ->
+        {:ok, result, eval.cache}
+
+      {:error, :timeout} ->
+        {:error, %Dx.Error.Timeout{configured_timeout: eval.loader_options[:timeout]}}
+
+      other ->
+        other
     end
   end
 

--- a/lib/dx/error/timeout.ex
+++ b/lib/dx/error/timeout.ex
@@ -1,7 +1,13 @@
 defmodule Dx.Error.Timeout do
-  defexception []
+  defexception [:configured_timeout]
 
-  def message(_error) do
-    "A timeout occurred while loading the data required."
+  def message(error) do
+    """
+    A timeout occurred while loading the data required.
+    The timeout is currently set to #{error.configured_timeout}.
+    If you are using the default `Dx.Loaders.Dataloader`, you can
+    increase the timeout by passing `loader_options: [timeout: your_timeout]`
+    to the `Dx.get/3` or whichever entry function you are using.
+    """
   end
 end

--- a/lib/dx/error/timeout.ex
+++ b/lib/dx/error/timeout.ex
@@ -7,7 +7,7 @@ defmodule Dx.Error.Timeout do
     The timeout is currently set to #{error.configured_timeout}.
     If you are using the default `Dx.Loaders.Dataloader`, you can
     increase the timeout by passing `loader_options: [timeout: your_timeout]`
-    to the `Dx.get/3` or whichever entry function you are using.
+    as last argument to the `Dx` function you are using, such as `Dx.load/3`.
     """
   end
 end

--- a/lib/dx/evaluation.ex
+++ b/lib/dx/evaluation.ex
@@ -23,7 +23,7 @@ defmodule Dx.Evaluation do
   end
 
   def from_options(opts) do
-    {opts, loader_opts} = Keyword.pop(opts, :loader, [])
+    {opts, loader_opts} = Keyword.pop(opts, :loader_options, [])
 
     %__MODULE__{}
     |> add_options(opts)

--- a/lib/dx/evaluation.ex
+++ b/lib/dx/evaluation.ex
@@ -23,10 +23,12 @@ defmodule Dx.Evaluation do
   end
 
   def from_options(opts) do
+    {opts, loader_opts} = Keyword.pop(opts, :loader, [])
+
     %__MODULE__{}
     |> add_options(opts)
     |> case do
-      %{cache: nil} = eval -> Map.put(eval, :cache, eval.loader.init())
+      %{cache: nil} = eval -> Map.put(eval, :cache, eval.loader.init(loader_opts))
       other -> other
     end
   end

--- a/lib/dx/evaluation.ex
+++ b/lib/dx/evaluation.ex
@@ -16,6 +16,7 @@ defmodule Dx.Evaluation do
 
     # Options
     field(:loader, module(), default: Dx.Loaders.Dataloader)
+    field(:loader_options, Keyword.t(), default: [])
     field(:args, map(), default: %{})
     field(:debug?, boolean(), default: false)
     field(:extra_rules, list(module()), default: [])
@@ -23,12 +24,10 @@ defmodule Dx.Evaluation do
   end
 
   def from_options(opts) do
-    {opts, loader_opts} = Keyword.pop(opts, :loader_options, [])
-
     %__MODULE__{}
     |> add_options(opts)
     |> case do
-      %{cache: nil} = eval -> Map.put(eval, :cache, eval.loader.init(loader_opts))
+      %{cache: nil} = eval -> Map.put(eval, :cache, eval.loader.init(eval.loader_options))
       other -> other
     end
   end
@@ -39,7 +38,7 @@ defmodule Dx.Evaluation do
       {:debug, debug}, eval -> %{eval | debug?: debug}
       {:return_cache, return_cache}, eval -> %{eval | return_cache?: return_cache}
       {:args, args}, eval -> %{eval | args: Map.new(args)}
-      {key, val}, eval -> Map.replace!(eval, key, val)
+      {key, val}, eval -> %{eval | key => val}
     end)
   end
 

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -1,6 +1,10 @@
 defmodule Dx.Loaders.Dataloader do
   @moduledoc """
   Uses `Dataloader` to load missing data incrementally.
+
+  ## Supported `loader_options` (passed to `dataloader`)
+  - `timeout`: Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 5000.
+  - `repo_options`: Options passed to the `Ecto.Repo` when loading data. Defaults to `[]`.
   """
 
   alias Dx.Result

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -6,8 +6,8 @@ defmodule Dx.Loaders.Dataloader do
 
   These options are passed to `Dataloader.Ecto.new/2`:
 
-  - `timeout`: Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 15_000.
-  - `repo_options`: Options passed to the `Ecto.Repo` when loading data. Defaults to `[]`.
+  - **timeout** Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 15_000.
+  - **repo_options** Options passed to the `Ecto.Repo` when loading data. Defaults to `[]`.
   """
 
   alias Dx.Result

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -56,14 +56,16 @@ defmodule Dx.Loaders.Dataloader do
     #   -> https://github.com/absinthe-graphql/dataloader/issues/129#issuecomment-965492108
     run_concurrently? = not db_conn_checked_out?(repo)
 
-    default_opts = [get_policy: :tuples, async: run_concurrently?]
-    opts = Keyword.merge(default_opts, opts[:dataloader] || [])
-    default_ecto_opts = [query: &Dx.Ecto.Query.from_options/2, async: run_concurrently?]
-    ecto_opts = Keyword.merge(default_ecto_opts, opts[:dataloader_ecto] || [])
+    ecto_opts = [
+      query: &Dx.Ecto.Query.from_options/2,
+      async: run_concurrently?,
+      repo_opts: opts[:repo_options] || [],
+      timeout: opts[:timeout] || Dataloader.default_timeout()
+    ]
 
     source = Dataloader.Ecto.new(repo, ecto_opts)
 
-    Dataloader.new(opts)
+    Dataloader.new(get_policy: :tuples, async: run_concurrently?)
     |> Dataloader.add_source(:assoc, source)
   end
 

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -56,13 +56,17 @@ defmodule Dx.Loaders.Dataloader do
     #   -> https://github.com/absinthe-graphql/dataloader/issues/129#issuecomment-965492108
     run_concurrently? = not db_conn_checked_out?(repo)
 
-    source =
-      Dataloader.Ecto.new(repo,
-        query: &Dx.Ecto.Query.from_options/2,
-        async: run_concurrently?
-      )
+    config = Application.get_env(:dx)
 
-    Dataloader.new(get_policy: :tuples, async: run_concurrently?)
+    default_opts = [get_policy: :tuples, async: run_concurrently?]
+    opts = Enum.into(config[:dataloader] || [], default_opts)
+
+    default_ecto_opts = [query: &Dx.Ecto.Query.from_options/2, async: run_concurrently?]
+    ecto_opts = Enum.into(config[:dataloader_ecto] || [], default_ecto_opts)
+
+    source = Dataloader.Ecto.new(repo, ecto_opts)
+
+    Dataloader.new(opts)
     |> Dataloader.add_source(:assoc, source)
   end
 

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -49,20 +49,17 @@ defmodule Dx.Loaders.Dataloader do
   defp where(opts, []), do: opts
   defp where(opts, conditions), do: Keyword.put(opts, :where, {:all, conditions})
 
-  def init() do
+  def init(opts \\ []) do
     repo = config(:repo)
 
     # workaround for dataloader incompatibility with transactions
     #   -> https://github.com/absinthe-graphql/dataloader/issues/129#issuecomment-965492108
     run_concurrently? = not db_conn_checked_out?(repo)
 
-    config = Application.get_env(:dx)
-
     default_opts = [get_policy: :tuples, async: run_concurrently?]
-    opts = Enum.into(config[:dataloader] || [], default_opts)
-
+    opts = Keyword.merge(default_opts, opts[:dataloader] || [])
     default_ecto_opts = [query: &Dx.Ecto.Query.from_options/2, async: run_concurrently?]
-    ecto_opts = Enum.into(config[:dataloader_ecto] || [], default_ecto_opts)
+    ecto_opts = Keyword.merge(default_ecto_opts, opts[:dataloader_ecto] || [])
 
     source = Dataloader.Ecto.new(repo, ecto_opts)
 

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -66,7 +66,7 @@ defmodule Dx.Loaders.Dataloader do
     ecto_opts = [
       query: &Dx.Ecto.Query.from_options/2,
       async: run_concurrently?,
-      repo_opts: opts[:repo_options] || [],
+      repo_opts: opts[:repo_options] || opts[:repo_opts] || [],
       timeout: opts[:timeout] || Dataloader.default_timeout()
     ]
 

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -2,7 +2,10 @@ defmodule Dx.Loaders.Dataloader do
   @moduledoc """
   Uses `Dataloader` to load missing data incrementally.
 
-  ## Supported `loader_options` (passed to `dataloader`)
+  ## Supported options
+  
+  These options are passed to `Dataloader.Ecto.new/2`:
+
   - `timeout`: Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 5000.
   - `repo_options`: Options passed to the `Ecto.Repo` when loading data. Defaults to `[]`.
   """

--- a/lib/dx/loaders/dataloader.ex
+++ b/lib/dx/loaders/dataloader.ex
@@ -3,10 +3,10 @@ defmodule Dx.Loaders.Dataloader do
   Uses `Dataloader` to load missing data incrementally.
 
   ## Supported options
-  
+
   These options are passed to `Dataloader.Ecto.new/2`:
 
-  - `timeout`: Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 5000.
+  - `timeout`: Timeout in milliseconds for `Dataloader` to wait for all data to be loaded. Defaults to 15_000.
   - `repo_options`: Options passed to the `Ecto.Repo` when loading data. Defaults to `[]`.
   """
 

--- a/lib/dx/result.ex
+++ b/lib/dx/result.ex
@@ -151,9 +151,6 @@ defmodule Dx.Result do
       iex> Dx.Result.unwrap!({:error, %ArgumentError{}})
       ** (ArgumentError) argument error
 
-      iex> Dx.Result.unwrap!({:error, :timeout})
-      ** (Dx.Error.Timeout) A timeout occurred while loading the data required.
-
       iex> Dx.Result.unwrap!({:error, :not_an_exception})
       ** (Dx.Error.Generic) Error occurred: :not_an_exception
   """
@@ -165,7 +162,6 @@ defmodule Dx.Result do
     do: reraise(e, stacktrace)
 
   def unwrap!({:error, e}) when is_exception(e), do: raise(e)
-  def unwrap!({:error, :timeout}), do: raise(Dx.Error.Timeout)
   def unwrap!({:error, e}), do: raise(Dx.Error.Generic, cause: e)
 
   @doc """

--- a/test/dx/query_one_test.exs
+++ b/test/dx/query_one_test.exs
@@ -73,7 +73,9 @@ defmodule Dx.QueryOneTest do
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
     end
 
-    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{tasks: [task | _]} do
+    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{
+      tasks: [task | _]
+    } do
       loader_opts = [timeout: 0]
 
       assert_raise Dx.Error.Timeout, fn ->

--- a/test/dx/query_one_test.exs
+++ b/test/dx/query_one_test.exs
@@ -146,5 +146,16 @@ defmodule Dx.QueryOneTest do
 
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
     end
+
+    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{
+      tasks: tasks,
+      calendar_overrides: calendar_overrides
+    } do
+      loader_opts = [timeout: 1]
+
+      assert_raise Dx.Error.Timeout, fn ->
+        Dx.load!(tasks, :calendar_overrides, extra_rules: Rules, loader_options: loader_opts)
+      end
+    end
   end
 end

--- a/test/dx/query_one_test.exs
+++ b/test/dx/query_one_test.exs
@@ -147,11 +147,8 @@ defmodule Dx.QueryOneTest do
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
     end
 
-    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{
-      tasks: tasks,
-      calendar_overrides: calendar_overrides
-    } do
-      loader_opts = [timeout: 1]
+    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{tasks: tasks} do
+      loader_opts = [timeout: 0]
 
       assert_raise Dx.Error.Timeout, fn ->
         Dx.load!(tasks, :calendar_overrides, extra_rules: Rules, loader_options: loader_opts)

--- a/test/dx/query_one_test.exs
+++ b/test/dx/query_one_test.exs
@@ -72,6 +72,14 @@ defmodule Dx.QueryOneTest do
 
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
     end
+
+    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{tasks: [task | _]} do
+      loader_opts = [timeout: 0]
+
+      assert_raise Dx.Error.Timeout, fn ->
+        Dx.load!(task, :calendar_override, extra_rules: Rules, loader_options: loader_opts)
+      end
+    end
   end
 
   describe "query_first" do
@@ -145,14 +153,6 @@ defmodule Dx.QueryOneTest do
                        %{source: "list_calendar_overrides", result: {:ok, %{num_rows: 4}}}}
 
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
-    end
-
-    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{tasks: tasks} do
-      loader_opts = [timeout: 0]
-
-      assert_raise Dx.Error.Timeout, fn ->
-        Dx.load!(tasks, :calendar_overrides, extra_rules: Rules, loader_options: loader_opts)
-      end
     end
   end
 end


### PR DESCRIPTION
Configure `Dataloader` and `Dataloader.Ecto`.

TODO:
- [x] Add docs explaining configuration

Elixir library docs: [Avoid application configuration](https://hexdocs.pm/elixir/library-guidelines.html#avoid-application-configuration)
> The solution is to provide configuration as close as possible to where it is used and not via the application environment. In case of a function, you could expect keyword lists as a new argument: 