### PR TITLE
WIP: Add timeout tests

### DIFF
--- a/lib/dx/ecto/query.ex
+++ b/lib/dx/ecto/query.ex
@@ -452,6 +452,7 @@ defmodule Dx.Ecto.Query do
       {:where, conditions}, {query, opts} -> {where(query, conditions), opts}
       {:limit, limit}, {query, opts} -> {limit(query, limit), opts}
       {:order_by, order}, {query, opts} -> {order_by(query, order), opts}
+      {:sleep, duration}, {query, opts} -> {sleep(query, duration), opts}
       other, {query, opts} -> {query, [other | opts]}
     end)
     |> case do
@@ -483,6 +484,10 @@ defmodule Dx.Ecto.Query do
       end)
 
     from(q in queryable, order_by: ^fields)
+  end
+
+  def sleep(queryable, duration) do
+    from(q in queryable, select: fragment("pg_sleep(?)", ^duration))
   end
 
   def inspect(query, repo) do

--- a/test/dx/query_one_test.exs
+++ b/test/dx/query_one_test.exs
@@ -72,16 +72,6 @@ defmodule Dx.QueryOneTest do
 
       refute_received {:ecto_query, %{source: "list_calendar_overrides"}}
     end
-
-    test "raises Dx.Error.Timeout if configurable dataloader timeout is exceeded", %{
-      tasks: [task | _]
-    } do
-      loader_opts = [timeout: 0]
-
-      assert_raise Dx.Error.Timeout, fn ->
-        Dx.load!(task, :calendar_override, extra_rules: Rules, loader_options: loader_opts)
-      end
-    end
   end
 
   describe "query_first" do

--- a/test/dx/timeout_test.exs
+++ b/test/dx/timeout_test.exs
@@ -1,0 +1,31 @@
+defmodule Dx.TimeoutTest do
+  use Dx.Test.DataLoadingCase
+
+  defmodule ExtraRules do
+    use Dx.Rules, for: Role
+    infer cause_timeout: {:query_one, Role, [name: "Role"], sleep: 9_999}
+  end
+
+  setup do
+    [role: create(Role, %{name: "Role"})]
+  end
+
+  describe "timeout" do
+    # Currently failing
+    test "raises Dx.Error.Timeout when ecto repo timeout is exceeded", %{role: role} do
+      loader_options = [repo_options: [timeout: 100], timeout: 999]
+
+      assert_raise Dx.Error.Timeout, fn ->
+        Dx.load!(role, :cause_timeout, extra_rules: ExtraRules, loader_options: loader_options)
+      end
+    end
+
+    test "raises Dx.Error.Timeout when dataloader timeout is exceeded", %{role: role} do
+      loader_options = [timeout: 100, repo_options: [timeout: 999]]
+
+      assert_raise Dx.Error.Timeout, fn ->
+        Dx.load!(role, :cause_timeout, extra_rules: ExtraRules, loader_options: loader_options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- currently raises `DBConnection.ConnectionError` when ecto timeout is exceeded

@arnodirlam does that match the observation in the engine live environment?

Todo:
- [x] add failing test
- [ ] re-raise ecto timeout as `Dx.Error.Timeout`