### PR TITLE
Annotations for extension API

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,8 @@
 locals_without_parens = [
   defd: 1,
   defd: 2,
+  defd_: 1,
+  defd_: 2,
   defdp: 1,
   defdp: 2,
   field_group: 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `defdp`: Private `defd` functions with proper 'unused' warnings
 - `case`: Support carets, assigns and data loading in map keys
 - `fn`: Support multiple clauses
-- Consolidate and document extension API (`Dx.Defd.Ext`)
+- Consolidate and document extension API (`Dx.Defd_`)
 
 ## [0.3.4] - 2024-10-12
 

--- a/lib/dx/date_time.ex
+++ b/lib/dx/date_time.ex
@@ -3,10 +3,7 @@ defmodule Dx.DateTime do
 
   use Dx.Defd_
 
-  @impl true
-  def __dx_fun_info(_fun_name, _arity) do
-    %FunInfo{args: %{all: :preload_scope}}
-  end
+  @moduledx_ args: %{all: :preload_scope}
 
   defscope after?(left, right, generate_fallback) do
     quote do: {:gt, unquote(left), unquote(right), unquote(generate_fallback.())}

--- a/lib/dx/date_time.ex
+++ b/lib/dx/date_time.ex
@@ -4,8 +4,8 @@ defmodule Dx.DateTime do
   use Dx.Defd_
 
   @impl true
-  def __dx_fun_info(_fun_name, arity) do
-    %FunInfo{args: List.duplicate(:preload_scope, arity)}
+  def __dx_fun_info(_fun_name, _arity) do
+    %FunInfo{args: %{all: :preload_scope}}
   end
 
   defscope after?(left, right, generate_fallback) do

--- a/lib/dx/date_time.ex
+++ b/lib/dx/date_time.ex
@@ -1,10 +1,10 @@
 defmodule Dx.DateTime do
   @moduledoc false
 
-  use Dx.Defd.Ext
+  use Dx.Defd_
 
   @impl true
-  def __fun_info(_fun_name, arity) do
+  def __dx_fun_info(_fun_name, arity) do
     %FunInfo{args: List.duplicate(:preload_scope, arity)}
   end
 

--- a/lib/dx/defd/ext/compiler.ex
+++ b/lib/dx/defd/ext/compiler.ex
@@ -1,0 +1,49 @@
+defmodule Dx.Defd.Ext.Compiler do
+  @moduledoc false
+
+  alias Dx.Defd.Ast
+
+  def __compile__(%Macro.Env{module: module}, fun_infos) do
+    existing_clauses =
+      case Module.get_definition(module, {:__fun_info, 2}) do
+        {:v1, :def, _meta, clauses} ->
+          Module.delete_definition(module, {:__fun_info, 2})
+
+          Enum.map(clauses, fn
+            {_meta, args, [], ast} ->
+              quote do
+                def __fun_info(unquote_splicing(args)) do
+                  unquote(ast)
+                end
+              end
+
+            {_meta, args, guards, ast} ->
+              quote do
+                def __fun_info(unquote_splicing(args)) when unquote_splicing(guards) do
+                  unquote(ast)
+                end
+              end
+          end)
+
+        _other ->
+          []
+      end
+
+    annotated_clauses =
+      Enum.flat_map(fun_infos, fn
+        {{name, arity}, %{fun_info: fun_info}} ->
+          quote do
+            def __fun_info(unquote(name), unquote(arity)) do
+              unquote(Macro.escape(fun_info))
+            end
+          end
+          |> List.wrap()
+
+        _else ->
+          []
+      end)
+
+    (annotated_clauses ++ existing_clauses)
+    |> Ast.block()
+  end
+end

--- a/lib/dx/defd/kernel.ex
+++ b/lib/dx/defd/kernel.ex
@@ -3,10 +3,7 @@ defmodule Dx.Defd.Kernel do
 
   use Dx.Defd_
 
-  @impl true
-  def __dx_fun_info(_fun_name, _arity) do
-    %FunInfo{args: %{all: :preload_scope}}
-  end
+  @moduledx_ args: %{all: :preload_scope}
 
   defscope unquote(:==)({:error, _left}, _right, generate_fallback) do
     {:error, generate_fallback.()}

--- a/lib/dx/defd/kernel.ex
+++ b/lib/dx/defd/kernel.ex
@@ -4,8 +4,8 @@ defmodule Dx.Defd.Kernel do
   use Dx.Defd_
 
   @impl true
-  def __dx_fun_info(_fun_name, arity) do
-    %FunInfo{args: List.duplicate(:preload_scope, arity)}
+  def __dx_fun_info(_fun_name, _arity) do
+    %FunInfo{args: %{all: :preload_scope}}
   end
 
   defscope unquote(:==)({:error, _left}, _right, generate_fallback) do

--- a/lib/dx/defd/kernel.ex
+++ b/lib/dx/defd/kernel.ex
@@ -1,10 +1,10 @@
 defmodule Dx.Defd.Kernel do
   @moduledoc false
 
-  use Dx.Defd.Ext
+  use Dx.Defd_
 
   @impl true
-  def __fun_info(_fun_name, arity) do
+  def __dx_fun_info(_fun_name, arity) do
     %FunInfo{args: List.duplicate(:preload_scope, arity)}
   end
 
@@ -26,15 +26,15 @@ defmodule Dx.Defd.Kernel do
     {:not, term}
   end
 
-  def is_function(%Dx.Defd.Fn{}) do
+  defd_ is_function(%Dx.Defd.Fn{}) do
     true
   end
 
-  def is_function(term) do
+  defd_ is_function(term) do
     :erlang.is_function(term)
   end
 
-  def is_function(term, arity) do
+  defd_ is_function(term, arity) do
     :erlang.is_function(term, arity)
   end
 end

--- a/lib/dx/defd/string/chars.ex
+++ b/lib/dx/defd/string/chars.ex
@@ -3,8 +3,5 @@ defmodule Dx.Defd.String.Chars do
 
   use Dx.Defd_
 
-  @impl true
-  def __dx_fun_info(_fun_name, _arity) do
-    %FunInfo{args: %{all: :preload_scope}}
-  end
+  @moduledx_ args: %{all: :preload_scope}
 end

--- a/lib/dx/defd/string/chars.ex
+++ b/lib/dx/defd/string/chars.ex
@@ -1,10 +1,10 @@
 defmodule Dx.Defd.String.Chars do
   @moduledoc false
 
-  use Dx.Defd.Ext
+  use Dx.Defd_
 
   @impl true
-  def __fun_info(_fun_name, arity) do
+  def __dx_fun_info(_fun_name, arity) do
     %FunInfo{args: List.duplicate(:preload_scope, arity)}
   end
 end

--- a/lib/dx/defd/string/chars.ex
+++ b/lib/dx/defd/string/chars.ex
@@ -4,7 +4,7 @@ defmodule Dx.Defd.String.Chars do
   use Dx.Defd_
 
   @impl true
-  def __dx_fun_info(_fun_name, arity) do
-    %FunInfo{args: List.duplicate(:preload_scope, arity)}
+  def __dx_fun_info(_fun_name, _arity) do
+    %FunInfo{args: %{all: :preload_scope}}
   end
 end

--- a/lib/dx/defd/util.ex
+++ b/lib/dx/defd/util.ex
@@ -2,7 +2,7 @@
 defmodule Dx.Defd.Util do
   @moduledoc false
 
-  alias Dx.Defd.Ext.FunInfo
+  alias Dx.Defd_.FunInfo
 
   @defd_exports_key :__defd_exports__
 
@@ -18,8 +18,8 @@ defmodule Dx.Defd.Util do
   def fun_info(module, fun_name, arity) do
     Code.ensure_loaded(module)
 
-    if function_exported?(module, :__fun_info, 2) do
-      module.__fun_info(fun_name, arity)
+    if function_exported?(module, :__dx_fun_info, 2) do
+      module.__dx_fun_info(fun_name, arity)
       |> FunInfo.new!(%{module: module, fun_name: fun_name, arity: arity})
     else
       %{}

--- a/lib/dx/defd_.ex
+++ b/lib/dx/defd_.ex
@@ -76,6 +76,8 @@ defmodule Dx.Defd_ do
   end
   ```
 
+  `args` options will also be derived for functions with omitted default arguments.
+
   2. Using the `@moduledx_` module attribute for module-wide defaults (can only be set once per module):
 
   ```elixir

--- a/lib/dx/defd_.ex
+++ b/lib/dx/defd_.ex
@@ -1,4 +1,4 @@
-defmodule Dx.Defd.Ext do
+defmodule Dx.Defd_ do
   @moduledoc """
   Used to make existing libraries compatible with `Dx.Defd`.
 
@@ -6,10 +6,10 @@ defmodule Dx.Defd.Ext do
 
   ```elixir
   defmodule MyExt do
-    use Dx.Defd.Ext
+    use Dx.Defd_
 
     @impl true
-    def __fun_info(fun_name, arity) do
+    def __dx_fun_info(fun_name, arity) do
       %FunInfo{args: [:preload_scope, %{}, :final_args_fn]}
     end
   end
@@ -33,21 +33,21 @@ defmodule Dx.Defd.Ext do
 
   defmacro __using__(_opts) do
     quote do
-      @behaviour Dx.Defd.Ext
+      @behaviour Dx.Defd_
 
-      alias Dx.Defd.Ext.ArgInfo
-      alias Dx.Defd.Ext.FunInfo
+      alias Dx.Defd_.ArgInfo
+      alias Dx.Defd_.FunInfo
 
-      import Dx.Defd.Ext
+      import Dx.Defd_
     end
   end
 
   @doc """
   This callback is used to provide information about a function to `Dx.Defd`.
   """
-  @callback __fun_info(atom(), non_neg_integer()) :: __MODULE__.FunInfo.input()
+  @callback __dx_fun_info(atom(), non_neg_integer()) :: __MODULE__.FunInfo.input()
 
-  @optional_callbacks __fun_info: 2
+  @optional_callbacks __dx_fun_info: 2
 
   alias Dx.Defd.Util
 
@@ -110,7 +110,7 @@ defmodule Dx.Defd.Ext do
         unquote(name),
         unquote(arity),
         %{unquote_splicing(defaults)},
-        Module.delete_attribute(__MODULE__, :dx)
+        Module.delete_attribute(__MODULE__, :dx_)
       )
 
       unquote(kind)(unquote(call))
@@ -131,7 +131,7 @@ defmodule Dx.Defd.Ext do
         unquote(name),
         unquote(arity),
         %{unquote_splicing(defaults)},
-        Module.delete_attribute(__MODULE__, :dx)
+        Module.delete_attribute(__MODULE__, :dx_)
       )
 
       unquote(kind)(unquote(call)) do
@@ -191,6 +191,10 @@ defmodule Dx.Defd.Ext do
   @defd__exports_key :__defd__exports__
 
   @doc false
+  def __define__(_env, _kind, _name, _arity, _defaults, nil) do
+    :ok
+  end
+
   def __define__(%Macro.Env{module: module} = env, kind, name, arity, defaults, opts) do
     exports =
       if exports = Module.get_attribute(module, @defd__exports_key) do
@@ -202,7 +206,7 @@ defmodule Dx.Defd.Ext do
 
     fun_info =
       try do
-        Dx.Defd.Ext.FunInfo.new!(opts || [], %{module: module, fun_name: name, arity: arity})
+        Dx.Defd_.FunInfo.new!(opts || [], %{module: module, fun_name: name, arity: arity})
       rescue
         e ->
           compile_error!(
@@ -237,6 +241,6 @@ defmodule Dx.Defd.Ext do
   defmacro __before_compile__(env) do
     defd__exports = Module.get_attribute(env.module, @defd__exports_key)
 
-    Dx.Defd.Ext.Compiler.__compile__(env, defd__exports)
+    Dx.Defd_.Compiler.__compile__(env, defd__exports)
   end
 end

--- a/lib/dx/defd_.ex
+++ b/lib/dx/defd_.ex
@@ -30,16 +30,10 @@ defmodule Dx.Defd_ do
 
   - `args` - list or map of argument indexes mapping to argument information
     - List format: `[:preload_scope, %{}, :fn]` - each element maps to an argument position
-    - Map format with special keys:
-      - Integer keys (0-based): `%{0 => :preload_scope}` - specific argument positions
-      - `:first` - applies to first argument
-      - `:last` - applies to last argument
-      - `:all` - applies to all arguments unless overridden
-
-    Precedence (highest to lowest):
-    1. Specific integer positions
-    2. `:first`/`:last` positions
-    3. `:all` default
+    - Map format with special keys (highest to lowest precedence):
+      - Positive argument indexes (0..arity-1) counting from the first argument: `%{0 => :preload_scope}`
+      - Negative argument indexes (-1..-arity) counting from the last argument: `%{-1 => :preload_scope}`
+      - `:all` - sets defaults for all arguments (explicitly defined or not)
 
   Argument information options:
     - `:atom_to_scope` - whether to wrap atoms in `Dx.Scope.all/1`
@@ -53,6 +47,32 @@ defmodule Dx.Defd_ do
   Additional options:
     - `warn_not_ok` - compiler warning to display when the function possibly loads data
     - `warn_always` - compiler warning to display when the function is used
+
+  ### Examples
+
+  ```elixir
+  defmodule MyExt do
+    use Dx.Defd_
+
+    # Using list format - positional arguments
+    @dx_ args: [:preload_scope, %{}, :final_args_fn]
+    defd_ my_function(scope, value, callback) do
+      # ...
+    end
+
+    # Using map format with positive and negative indexes
+    @dx_ args: %{0 => :preload_scope, -1 => :fn}, warn_not_ok: "Be careful!"
+    defd_ another_function(scope, value, callback) do
+      # ...
+    end
+
+    # Using :all to set defaults for all arguments
+    @dx_ args: %{all: :atom_to_scope, 0 => :preload_scope}
+    defd_ process_all(first, second, third) do
+      # first will be :preload_scope, all will have :atom_to_scope
+    end
+  end
+  ```
 
   ## Compiler annotations & callbacks
 
@@ -69,7 +89,7 @@ defmodule Dx.Defd_ do
       # ...
     end
 
-    @dx_ args: %{first: :preload_scope}, warn_not_ok: "Be careful!"
+    @dx_ args: %{0 => :preload_scope}, warn_not_ok: "Be careful!"
     defd_ another_function(scope, value) do
       # ...
     end

--- a/lib/dx/defd_/arg_info.ex
+++ b/lib/dx/defd_/arg_info.ex
@@ -1,8 +1,8 @@
-defmodule Dx.Defd.Ext.ArgInfo do
+defmodule Dx.Defd_.ArgInfo do
   @moduledoc false
 
-  alias Dx.Defd.Ext.ArgInfo
-  alias Dx.Defd.Ext.FunInfo
+  alias Dx.Defd_.ArgInfo
+  alias Dx.Defd_.FunInfo
 
   defstruct atom_to_scope: false,
             preload_scope: false,

--- a/lib/dx/defd_/arg_info.ex
+++ b/lib/dx/defd_/arg_info.ex
@@ -40,12 +40,28 @@ defmodule Dx.Defd_.ArgInfo do
 
   @spec new!(input()) :: t()
   def new!(%ArgInfo{} = arg_info), do: arg_info
-  def new!(field) when is_atom(field), do: new!([field])
+  def new!(fields), do: struct!(ArgInfo, normalize_fields(fields))
 
-  def new!(fields) when is_list(fields) or is_map(fields),
-    do: struct!(ArgInfo, Enum.map(fields, &field!/1))
+  @spec new!(input(), input()) :: t()
+  def new!(%ArgInfo{} = arg_info, extra_fields) do
+    struct!(arg_info, normalize_fields(extra_fields))
+  end
 
-  def new!(fields), do: new!(List.wrap(fields))
+  def new!(fields, extra_fields) do
+    new!(fields)
+    |> new!(extra_fields)
+  end
+
+  defp normalize_fields(fields) when is_map(fields) do
+    fields
+    |> Enum.map(&field!/1)
+  end
+
+  defp normalize_fields(fields) do
+    fields
+    |> List.wrap()
+    |> Enum.map(&field!/1)
+  end
 
   defp field!(field) when field in @fun_fields, do: {field, FunInfo.new!()}
   defp field!(field) when is_atom(field), do: {field, true}

--- a/lib/dx/defd_/compiler.ex
+++ b/lib/dx/defd_/compiler.ex
@@ -3,7 +3,7 @@ defmodule Dx.Defd_.Compiler do
 
   alias Dx.Defd.Ast
 
-  def __compile__(%Macro.Env{module: module}, moduledx_, fun_infos) do
+  def __compile__(%Macro.Env{module: module}, moduledx_, defd_s) do
     existing_clauses =
       case Module.get_definition(module, {:__dx_fun_info, 2}) do
         {:v1, :def, _meta, clauses} ->
@@ -29,9 +29,30 @@ defmodule Dx.Defd_.Compiler do
           []
       end
 
+    # derive fun info for omitting default arguments
+    fun_infos =
+      Enum.reduce(defd_s, defd_s, fn
+        {{name, _arity} = key, %{defaults: defaults, fun_info: fun_info}}, acc ->
+          defaults
+          |> Map.keys()
+          |> Enum.sort(:desc)
+          |> Enum.reduce({fun_info, acc}, fn arg_index, {fun_info, acc} ->
+            fun_info = %{
+              fun_info
+              | args: List.delete_at(fun_info.args, arg_index),
+                arity: fun_info.arity - 1
+            }
+
+            acc = Map.put_new(acc, {name, fun_info.arity}, fun_info)
+            {fun_info, acc}
+          end)
+          |> elem(1)
+          |> Map.put(key, fun_info)
+      end)
+
     annotated_clauses =
       Enum.flat_map(fun_infos, fn
-        {{name, arity}, %{fun_info: fun_info}} ->
+        {{name, arity}, fun_info} ->
           quote do
             def __dx_fun_info(unquote(name), unquote(arity)) do
               unquote(Macro.escape(fun_info))

--- a/lib/dx/defd_/compiler.ex
+++ b/lib/dx/defd_/compiler.ex
@@ -1,25 +1,25 @@
-defmodule Dx.Defd.Ext.Compiler do
+defmodule Dx.Defd_.Compiler do
   @moduledoc false
 
   alias Dx.Defd.Ast
 
   def __compile__(%Macro.Env{module: module}, fun_infos) do
     existing_clauses =
-      case Module.get_definition(module, {:__fun_info, 2}) do
+      case Module.get_definition(module, {:__dx_fun_info, 2}) do
         {:v1, :def, _meta, clauses} ->
-          Module.delete_definition(module, {:__fun_info, 2})
+          Module.delete_definition(module, {:__dx_fun_info, 2})
 
           Enum.map(clauses, fn
             {_meta, args, [], ast} ->
               quote do
-                def __fun_info(unquote_splicing(args)) do
+                def __dx_fun_info(unquote_splicing(args)) do
                   unquote(ast)
                 end
               end
 
             {_meta, args, guards, ast} ->
               quote do
-                def __fun_info(unquote_splicing(args)) when unquote_splicing(guards) do
+                def __dx_fun_info(unquote_splicing(args)) when unquote_splicing(guards) do
                   unquote(ast)
                 end
               end
@@ -33,7 +33,7 @@ defmodule Dx.Defd.Ext.Compiler do
       Enum.flat_map(fun_infos, fn
         {{name, arity}, %{fun_info: fun_info}} ->
           quote do
-            def __fun_info(unquote(name), unquote(arity)) do
+            def __dx_fun_info(unquote(name), unquote(arity)) do
               unquote(Macro.escape(fun_info))
             end
           end

--- a/lib/dx/defd_/compiler.ex
+++ b/lib/dx/defd_/compiler.ex
@@ -3,7 +3,7 @@ defmodule Dx.Defd_.Compiler do
 
   alias Dx.Defd.Ast
 
-  def __compile__(%Macro.Env{module: module}, fun_infos) do
+  def __compile__(%Macro.Env{module: module}, moduledx_, fun_infos) do
     existing_clauses =
       case Module.get_definition(module, {:__dx_fun_info, 2}) do
         {:v1, :def, _meta, clauses} ->
@@ -43,7 +43,14 @@ defmodule Dx.Defd_.Compiler do
           []
       end)
 
-    (annotated_clauses ++ existing_clauses)
+    fallback_clause =
+      quote do
+        def __dx_fun_info(_fun_name, _arity) do
+          unquote(Macro.escape(moduledx_))
+        end
+      end
+
+    (annotated_clauses ++ existing_clauses ++ [fallback_clause])
     |> Ast.block()
   end
 end

--- a/lib/dx/defd_/fun_info.ex
+++ b/lib/dx/defd_/fun_info.ex
@@ -110,19 +110,26 @@ defmodule Dx.Defd_.FunInfo do
       %FunInfo{args: [%ArgInfo{atom_to_scope: true}], warn_always: "WARNING", arity: 1}
   """
 
-  @spec new!(input(), keyword() | %{atom() => term()}) :: t()
-  def new!(fun_info \\ %FunInfo{}, extra_fields \\ [])
+  @spec new!(
+          input(),
+          keyword() | %{atom() => term()},
+          keyword() | %{atom() => term()},
+          keyword() | %{atom() => term()}
+        ) :: t()
+  def new!(fields \\ [], extra_fields1 \\ [], extra_fields2 \\ [], extra_fields3 \\ [])
 
-  def new!(%FunInfo{} = fun_info, extra_fields) do
+  def new!(%FunInfo{} = fun_info, extra_fields1, extra_fields2, extra_fields3) do
     fun_info
-    |> struct!(extra_fields)
+    |> struct!(extra_fields1)
+    |> struct!(extra_fields2)
+    |> struct!(extra_fields3)
     |> args!()
   end
 
-  def new!(fields, extra_fields) do
+  def new!(fields, extra_fields1, extra_fields2, extra_fields3) do
     FunInfo
     |> struct!(fields)
-    |> new!(extra_fields)
+    |> new!(extra_fields1, extra_fields2, extra_fields3)
   end
 
   defp args!(%FunInfo{arity: nil} = fun_info), do: fun_info

--- a/lib/dx/defd_/fun_info.ex
+++ b/lib/dx/defd_/fun_info.ex
@@ -1,8 +1,8 @@
-defmodule Dx.Defd.Ext.FunInfo do
+defmodule Dx.Defd_.FunInfo do
   @moduledoc false
 
-  alias Dx.Defd.Ext.ArgInfo
-  alias Dx.Defd.Ext.FunInfo
+  alias Dx.Defd_.ArgInfo
+  alias Dx.Defd_.FunInfo
 
   defstruct module: nil,
             fun_name: nil,
@@ -17,7 +17,7 @@ defmodule Dx.Defd.Ext.FunInfo do
           fun_name: atom() | nil,
           arity: non_neg_integer() | nil,
           args:
-            %{non_neg_integer() => Dx.Defd.Ext.ArgInfo.input()}
+            %{non_neg_integer() => Dx.Defd_.ArgInfo.input()}
             | list()
             | nil,
           can_return_scope: boolean(),
@@ -30,8 +30,8 @@ defmodule Dx.Defd.Ext.FunInfo do
           fun_name: atom(),
           arity: non_neg_integer(),
           args:
-            %{non_neg_integer() => Dx.Defd.Ext.ArgInfo.t()}
-            | list(Dx.Defd.Ext.ArgInfo.t())
+            %{non_neg_integer() => Dx.Defd_.ArgInfo.t()}
+            | list(Dx.Defd_.ArgInfo.t())
             | nil,
           can_return_scope: boolean(),
           warn_not_ok: binary() | nil,

--- a/lib/dx/enum.ex
+++ b/lib/dx/enum.ex
@@ -174,196 +174,42 @@ defmodule Dx.Enum do
       end)
   """
 
-  @static_warnings %{
-    {:each, 2} => @each_warning
-  }
-
   @impl true
-  def __fun_info(fun_name, arity) do
+  def __fun_info(:zip, 2) do
     %FunInfo{
-      args: arg_info(fun_name, arity),
-      can_return_scope: can_return_scope(fun_name, arity),
-      warn_always: Map.get(@static_warnings, {fun_name, arity})
+      args: [
+        [:atom_to_scope, :preload_scope],
+        [:atom_to_scope, :preload_scope]
+      ]
     }
   end
 
-  defp can_return_scope(:count, 1), do: true
-  defp can_return_scope(:find, 2), do: true
-  defp can_return_scope(:filter, 2), do: true
-  defp can_return_scope(_fun_name, _arity), do: false
+  def __fun_info(:zip_with, 3) do
+    %FunInfo{
+      args: [
+        [:atom_to_scope, :preload_scope],
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn
+      ]
+    }
+  end
 
-  defp arg_info(:chunk_while, 4),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, arity: 2, warn_not_ok: @chunk_while_chunk_fun_warning},
-      :final_args_fn
-    ]
+  def __fun_info(_fun_name, 1) do
+    %FunInfo{
+      args: [
+        [:atom_to_scope, :preload_scope]
+      ]
+    }
+  end
 
-  defp arg_info(:count_until, 3), do: [[:atom_to_scope, :preload_scope], :final_args_fn, %{}]
-
-  defp arg_info(:filter_map, 3),
-    do: [[:atom_to_scope, :preload_scope], :final_args_fn, :final_args_fn]
-
-  defp arg_info(:flat_map_reduce, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @flat_map_reduce_warning}
-    ]
-
-  defp arg_info(:group_by, 3),
-    do: [[:atom_to_scope, :preload_scope], :final_args_fn, :final_args_fn]
-
-  defp arg_info(:map_reduce, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @map_reduce_warning}
-    ]
-
-  defp arg_info(:max, 2),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, arity: 2, warn_not_ok: @max_warning}
-    ]
-
-  defp arg_info(:max, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, arity: 2, warn_not_ok: @max_warning},
-      :final_args_fn
-    ]
-
-  defp arg_info(:max_by, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
-    ]
-
-  defp arg_info(:max_by, 4),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
-      :final_args_fn
-    ]
-
-  defp arg_info(:min, 2),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, arity: 2, warn_not_ok: @min_warning}
-    ]
-
-  defp arg_info(:min, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, arity: 2, warn_not_ok: @min_warning},
-      :final_args_fn
-    ]
-
-  defp arg_info(:min_by, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
-    ]
-
-  defp arg_info(:min_by, 4),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
-      :final_args_fn
-    ]
-
-  defp arg_info(:min_max_by, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
-    ]
-
-  defp arg_info(:min_max_by, 4),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
-      :final_args_fn
-    ]
-
-  defp arg_info(:reduce, 2),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, warn_not_ok: @reduce_warning}
-    ]
-
-  defp arg_info(:reduce, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @reduce_warning}
-    ]
-
-  defp arg_info(:reduce_while, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @reduce_while_warning}
-    ]
-
-  defp arg_info(:scan, 2),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, warn_not_ok: @scan_warning}
-    ]
-
-  defp arg_info(:scan, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @scan_warning}
-    ]
-
-  defp arg_info(:sort, 2),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, warn_not_ok: @sort_warning}
-    ]
-
-  defp arg_info(:sort_by, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      :final_args_fn,
-      {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
-    ]
-
-  defp arg_info(:zip, 2), do: [[:atom_to_scope, :preload_scope], [:atom_to_scope, :preload_scope]]
-
-  defp arg_info(:zip_reduce, 3),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      [:atom_to_scope, :preload_scope],
-      {:final_args_fn, warn_not_ok: @zip_reduce_3_warning}
-    ]
-
-  defp arg_info(:zip_reduce, 4),
-    do: [
-      [:atom_to_scope, :preload_scope],
-      [:atom_to_scope, :preload_scope],
-      %{},
-      {:final_args_fn, warn_not_ok: @zip_reduce_4_warning}
-    ]
-
-  defp arg_info(:zip_with, 3),
-    do: [[:atom_to_scope, :preload_scope], [:atom_to_scope, :preload_scope], :final_args_fn]
-
-  # defp arg_info(_fun_name, 1), do: [:preload_scope]
-  defp arg_info(_fun_name, 1), do: [[:atom_to_scope, :preload_scope]]
-
-  defp arg_info(_fun_name, arity),
-    do: %{0 => [:atom_to_scope, :preload_scope], (arity - 1) => :final_args_fn}
+  def __fun_info(_fun_name, arity) do
+    %FunInfo{
+      args: %{
+        0 => [:atom_to_scope, :preload_scope],
+        (arity - 1) => :final_args_fn
+      }
+    }
+  end
 
   defscope all?(enumerable, fun, _generate_fallback) do
     quote do: {:not, {:any?, {:filter, unquote(enumerable), {:not, unquote(fun)}}}}
@@ -406,7 +252,13 @@ defmodule Dx.Enum do
     end)
   end
 
-  def chunk_while(enumerable, acc, chunk_fun, after_fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, arity: 2, warn_not_ok: @chunk_while_chunk_fun_warning},
+        :final_args_fn
+      ]
+  defd_ chunk_while(enumerable, acc, chunk_fun, after_fun) do
     Result.reduce_while(enumerable, {[], acc}, fn entry, {buffer, acc} ->
       chunk_fun.(entry, acc)
       |> Result.transform_while(fn
@@ -428,24 +280,14 @@ defmodule Dx.Enum do
     quote do: {:count, unquote(base)}
   end
 
-  def count(module) when is_atom(module) do
-    Dx.Scope.all(module)
-    |> count()
-  end
-
-  def count({:ok, %Dx.Scope{} = scope}) do
+  @dx can_return_scope: true, args: [:atom_to_scope]
+  defd_ count(%Dx.Scope{} = scope) do
     scope = %{scope | plan: {:count, scope.plan}}
 
     {:ok, scope}
   end
 
-  def count(%Dx.Scope{} = scope) do
-    scope = %{scope | plan: {:count, scope.plan}}
-
-    {:ok, scope}
-  end
-
-  def count(enumerable) do
+  defd_ count(enumerable) do
     {:ok, Enum.count(enumerable)}
   end
 
@@ -455,7 +297,8 @@ defmodule Dx.Enum do
     end)
   end
 
-  def count_until(enumerable, fun, limit) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn, %{}]
+  defd_ count_until(enumerable, fun, limit) do
     stop_at = limit - 1
 
     Result.map_then_reduce_ok_while(enumerable, fun, 0, fn
@@ -484,7 +327,8 @@ defmodule Dx.Enum do
     |> Result.transform(&:lists.reverse/1)
   end
 
-  def each(enumerable, fun) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn], warn_always: @each_warning
+  defd_ each(enumerable, fun) do
     map(enumerable, fun)
     |> Result.transform(fn _ -> :ok end)
   end
@@ -493,18 +337,14 @@ defmodule Dx.Enum do
     quote do: {:filter, unquote(base), unquote(condition)}
   end
 
-  def filter(module, conditions) when is_atom(module) do
-    Dx.Scope.all(module)
-    |> filter(conditions)
-  end
-
-  def filter(%Dx.Scope{} = scope, conditions) do
+  @dx can_return_scope: true, args: [:atom_to_scope]
+  defd_ filter(%Dx.Scope{} = scope, conditions) do
     scope = Dx.Scope.add_conditions(scope, conditions)
 
     {:ok, scope}
   end
 
-  def filter(enumerable, %Dx.Defd.Fn{final_args_fun: fun}) do
+  defd_ filter(enumerable, %Dx.Defd.Fn{final_args_fun: fun}) do
     Result.map_then_reduce_ok(enumerable, fun, [], fn elem, mapped, acc ->
       if mapped, do: [elem | acc], else: acc
     end)
@@ -513,17 +353,14 @@ defmodule Dx.Enum do
 
   @doc false
   @deprecated "Use Enum.filter/2 + Enum.map/2 or for comprehensions instead"
-  def filter_map(enumerable, filter, mapper) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn, :final_args_fn]
+  defd_ filter_map(enumerable, filter, mapper) do
     filter(enumerable, %Dx.Defd.Fn{final_args_fun: filter})
     |> Result.then(&map(&1, mapper))
   end
 
-  def find(module, conditions) when is_atom(module) do
-    Dx.Scope.all(module)
-    |> find(conditions)
-  end
-
-  def find(%Dx.Scope{} = scope, conditions) do
+  @dx can_return_scope: true, args: [:atom_to_scope]
+  defd_ find(%Dx.Scope{} = scope, conditions) do
     scope =
       scope
       |> Dx.Scope.add_conditions(conditions)
@@ -532,7 +369,12 @@ defmodule Dx.Enum do
     {:ok, scope}
   end
 
-  def find(enumerable, default \\ nil, %Dx.Defd.Fn{final_args_fun: fun}) do
+  defd_ find(enumerable, %Dx.Defd.Fn{final_args_fun: fun}) do
+    Result.find(enumerable, fun, &Result.ok/1, Result.ok(nil))
+  end
+
+  @dx args: [[:atom_to_scope, :preload_scope], [], :final_args_fn]
+  defd_ find(enumerable, default, fun) do
     Result.find(enumerable, fun, &Result.ok/1, Result.ok(default))
   end
 
@@ -556,7 +398,12 @@ defmodule Dx.Enum do
     |> Result.transform(&flat_reverse(&1, []))
   end
 
-  def flat_map_reduce(enumerable, acc, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @flat_map_reduce_warning}
+      ]
+  defd_ flat_map_reduce(enumerable, acc, fun) do
     Result.reduce_while(enumerable, {[], acc}, fn elem, {list, acc} ->
       fun.(elem, acc)
       |> Result.transform(fn
@@ -589,7 +436,8 @@ defmodule Dx.Enum do
     end)
   end
 
-  def group_by(enumerable, key_fun) when is_function(key_fun) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn]
+  defd_ group_by(enumerable, key_fun) when is_function(key_fun) do
     Result.map_then_reduce_ok(enumerable, key_fun, %{}, fn elem, mapped_key, acc ->
       Map.update(acc, mapped_key, [elem], &[elem | &1])
     end)
@@ -598,8 +446,9 @@ defmodule Dx.Enum do
     end)
   end
 
-  def group_by(enumerable, key_fun, value_fun)
-      when is_function(key_fun) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn, :final_args_fn]
+  defd_ group_by(enumerable, key_fun, value_fun)
+        when is_function(key_fun) do
     Result.map_then_reduce_ok(
       enumerable,
       &Result.collect_reverse([key_fun.(&1), value_fun.(&1)]),
@@ -668,7 +517,12 @@ defmodule Dx.Enum do
     |> Result.transform(&IO.iodata_to_binary/1)
   end
 
-  def map_reduce(enumerable, acc, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @map_reduce_warning}
+      ]
+  defd_ map_reduce(enumerable, acc, fun) do
     Result.reduce(enumerable, {[], acc}, fn elem, {list, acc} ->
       fun.(elem, acc)
       |> Result.transform(fn
@@ -680,14 +534,23 @@ defmodule Dx.Enum do
     end)
   end
 
-  def max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, arity: 2, warn_not_ok: @max_warning}
+      ]
+  defd_ max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     case Enum.max(enumerable, fn -> :empty end) do
       :empty -> empty_fallback.()
       max -> {:ok, max}
     end
   end
 
-  def max(enumerable, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, arity: 2, warn_not_ok: @max_warning},
+        :final_args_fn
+      ]
+  defd_ max(enumerable, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end) do
     sorter = max_sort_fun(sorter)
 
     Result.reduce(enumerable, fn elem, acc ->
@@ -703,17 +566,29 @@ defmodule Dx.Enum do
   defp max_sort_fun(sorter) when is_function(sorter, 2), do: sorter
   defp max_sort_fun(module) when is_atom(module), do: &{:ok, module.compare(&1, &2) != :lt}
 
-  def max_by(enumerable, fun) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn]
+  defd_ max_by(enumerable, fun) do
     max_by(enumerable, fun, fn -> raise Enum.EmptyError end)
   end
 
-  def max_by(enumerable, fun, empty_fallback)
-      when is_function(fun, 1) and is_function(empty_fallback, 0) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
+      ]
+  defd_ max_by(enumerable, fun, empty_fallback)
+        when is_function(fun, 1) and is_function(empty_fallback, 0) do
     max_by(enumerable, fun, &{:ok, &1 >= &2}, empty_fallback)
   end
 
-  def max_by(enumerable, fun, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end)
-      when is_function(fun, 1) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
+        :final_args_fn
+      ]
+  defd_ max_by(enumerable, fun, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end)
+        when is_function(fun, 1) do
     first_fun = fn elem -> fun.(elem) |> Result.transform(&{elem, &1}) end
     sorter = max_sort_fun(sorter)
 
@@ -727,14 +602,23 @@ defmodule Dx.Enum do
     |> Result.transform(empty_fallback, &elem(&1, 0))
   end
 
-  def min(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, arity: 2, warn_not_ok: @min_warning}
+      ]
+  defd_ min(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     case Enum.min(enumerable, fn -> :empty end) do
       :empty -> empty_fallback.()
       min -> {:ok, min}
     end
   end
 
-  def min(enumerable, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, arity: 2, warn_not_ok: @min_warning},
+        :final_args_fn
+      ]
+  defd_ min(enumerable, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end) do
     Result.reduce(enumerable, fn elem, acc ->
       sorter.(acc, elem)
       |> Result.transform(fn
@@ -745,17 +629,29 @@ defmodule Dx.Enum do
     |> Result.transform(empty_fallback)
   end
 
-  def min_by(enumerable, fun) when is_function(fun, 1) do
+  @dx args: [[:atom_to_scope, :preload_scope], :final_args_fn]
+  defd_ min_by(enumerable, fun) when is_function(fun, 1) do
     min_by(enumerable, fun, &{:ok, &1 <= &2}, fn -> raise Enum.EmptyError end)
   end
 
-  def min_by(enumerable, fun, empty_fallback)
-      when is_function(fun, 1) and is_function(empty_fallback, 0) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
+      ]
+  defd_ min_by(enumerable, fun, empty_fallback)
+        when is_function(fun, 1) and is_function(empty_fallback, 0) do
     min_by(enumerable, fun, &{:ok, &1 <= &2}, empty_fallback)
   end
 
-  def min_by(enumerable, fun, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end)
-      when is_function(fun, 1) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
+        :final_args_fn
+      ]
+  defd_ min_by(enumerable, fun, sorter, empty_fallback \\ fn -> raise Enum.EmptyError end)
+        when is_function(fun, 1) do
     first_fun = fn elem -> fun.(elem) |> Result.transform(&{elem, &1}) end
     sorter = min_sort_fun(sorter)
 
@@ -780,17 +676,30 @@ defmodule Dx.Enum do
     end
   end
 
-  def min_max_by(enumerable, fun, empty_fallback)
-      when is_function(fun, 1) and is_function(empty_fallback, 0) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
+      ]
+  defd_ min_max_by(enumerable, fun, empty_fallback)
+        when is_function(fun, 1) and is_function(empty_fallback, 0) do
     min_max_by(enumerable, fun, &{:ok, &1 < &2}, empty_fallback)
   end
 
-  def min_max_by(
-        enumerable,
-        fun,
-        sorter_or_empty_fallback \\ &{:ok, &1 < &2},
-        empty_fallback \\ fn -> raise Enum.EmptyError end
-      )
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning},
+        :final_args_fn
+      ]
+  defd_(
+    min_max_by(
+      enumerable,
+      fun,
+      sorter_or_empty_fallback \\ &{:ok, &1 < &2},
+      empty_fallback \\ fn -> raise Enum.EmptyError end
+    )
+  )
 
   def min_max_by(enumerable, fun, sorter, empty_fallback)
       when is_function(fun, 1) and is_atom(sorter) and is_function(empty_fallback, 0) do
@@ -829,30 +738,38 @@ defmodule Dx.Enum do
     split_with(enumerable, fun)
   end
 
-  def reduce([h | t], fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, warn_not_ok: @reduce_warning}
+      ]
+  defd_ reduce([h | t], fun) do
     reduce(t, h, fun)
   end
 
-  def reduce([], _fun) do
+  defd_ reduce([], _fun) do
     raise Enum.EmptyError
   end
 
-  def reduce(enumerable, fun) do
+  defd_ reduce(enumerable, fun) do
     Result.reduce(enumerable, fun)
     |> Result.transform()
   end
 
-  def reduce(enumerable, acc, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @reduce_warning}
+      ]
+  defd_ reduce(enumerable, acc, fun) do
     Result.reduce(enumerable, acc, fun)
-    # Enum.reduce_while(enumerable, Result.ok(acc), fn elem, {:ok, acc} ->
-    #   case fun.(elem, acc) do
-    #     {:ok, _} = result -> {:cont, result}
-    #     other -> {:halt, other}
-    #   end
-    # end)
   end
 
-  def reduce_while(enumerable, acc, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @reduce_while_warning}
+      ]
+  defd_ reduce_while(enumerable, acc, fun) do
     Result.reduce_while(enumerable, acc, fun)
   end
 
@@ -863,8 +780,11 @@ defmodule Dx.Enum do
     |> Result.transform(&:lists.reverse/1)
   end
 
-  # TODO: warn
-  def scan(enumerable, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, warn_not_ok: @scan_warning}
+      ]
+  defd_ scan(enumerable, fun) do
     Result.reduce(enumerable, [], fn
       entry, [] ->
         {:ok, [entry]}
@@ -876,8 +796,12 @@ defmodule Dx.Enum do
     |> Result.transform(&:lists.reverse/1)
   end
 
-  # TODO: warn
-  def scan(enumerable, acc, fun) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @scan_warning}
+      ]
+  defd_ scan(enumerable, acc, fun) do
     Result.reduce(enumerable, {:empty, acc}, fn
       entry, {:empty, acc} ->
         fun.(entry, acc)
@@ -893,7 +817,11 @@ defmodule Dx.Enum do
     end)
   end
 
-  def sort(enumerable, sorter) when is_function(sorter, 2) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, warn_not_ok: @sort_warning}
+      ]
+  defd_ sort(enumerable, sorter) when is_function(sorter, 2) do
     Result.reduce(enumerable, [], &sort_reducer(&1, &2, sorter))
     |> Result.then(&sort_terminator(&1, sorter))
   end
@@ -908,9 +836,14 @@ defmodule Dx.Enum do
   defp to_sort_fun({:desc, module}) when is_atom(module),
     do: &{:ok, module.compare(&1, &2) != :lt}
 
-  def sort_by(enumerable, mapper, sorter \\ :asc)
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        :final_args_fn,
+        {:final_args_fn, arity: 2, warn_not_ok: @sorter_warning}
+      ]
+  defd_ sort_by(enumerable, mapper, sorter \\ :asc)
 
-  def sort_by(enumerable, mapper, :desc) when is_function(mapper, 1) do
+  defd_ sort_by(enumerable, mapper, :desc) when is_function(mapper, 1) do
     enumerable
     |> Result.map_then_reduce_ok(mapper, [], &[{&1, &2} | &3])
     |> Result.transform(fn list ->
@@ -920,7 +853,7 @@ defmodule Dx.Enum do
     end)
   end
 
-  def sort_by(enumerable, mapper, sorter) when is_function(mapper, 1) do
+  defd_ sort_by(enumerable, mapper, sorter) when is_function(mapper, 1) do
     fun = to_sort_fun(sorter)
 
     enumerable
@@ -1016,12 +949,22 @@ defmodule Dx.Enum do
     |> Result.map(fn elems -> elems |> Tuple.to_list() |> zip_fun.() end)
   end
 
-  # TODO: warn
-  def zip_reduce(left, right, acc, reducer) when is_function(reducer, 3) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        [:atom_to_scope, :preload_scope],
+        %{},
+        {:final_args_fn, warn_not_ok: @zip_reduce_4_warning}
+      ]
+  defd_ zip_reduce(left, right, acc, reducer) when is_function(reducer, 3) do
     zip_reduce([left, right], acc, fn [elem1, elem2], acc -> reducer.(elem1, elem2, acc) end)
   end
 
-  def zip_reduce(enums, acc, reducer) when is_function(reducer, 2) do
+  @dx args: [
+        [:atom_to_scope, :preload_scope],
+        [:atom_to_scope, :preload_scope],
+        {:final_args_fn, warn_not_ok: @zip_reduce_3_warning}
+      ]
+  defd_ zip_reduce(enums, acc, reducer) when is_function(reducer, 2) do
     Stream.zip(enums)
     |> Result.reduce(acc, fn elems, acc -> elems |> Tuple.to_list() |> reducer.(acc) end)
   end

--- a/lib/dx/enum.ex
+++ b/lib/dx/enum.ex
@@ -202,13 +202,8 @@ defmodule Dx.Enum do
     }
   end
 
-  def __dx_fun_info(_fun_name, arity) do
-    %FunInfo{
-      args: %{
-        0 => [:atom_to_scope, :preload_scope],
-        (arity - 1) => :final_args_fn
-      }
-    }
+  def __dx_fun_info(_fun_name, _arity) do
+    %FunInfo{args: %{first: [:atom_to_scope, :preload_scope], last: :final_args_fn}}
   end
 
   defscope all?(enumerable, fun, _generate_fallback) do

--- a/lib/dx/enum.ex
+++ b/lib/dx/enum.ex
@@ -202,9 +202,7 @@ defmodule Dx.Enum do
     }
   end
 
-  def __dx_fun_info(_fun_name, _arity) do
-    %FunInfo{args: %{first: [:atom_to_scope, :preload_scope], last: :final_args_fn}}
-  end
+  @moduledx_ args: %{first: [:atom_to_scope, :preload_scope], last: :final_args_fn}
 
   defscope all?(enumerable, fun, _generate_fallback) do
     quote do: {:not, {:any?, {:filter, unquote(enumerable), {:not, unquote(fun)}}}}

--- a/lib/dx/enum.ex
+++ b/lib/dx/enum.ex
@@ -194,15 +194,7 @@ defmodule Dx.Enum do
     }
   end
 
-  def __dx_fun_info(_fun_name, 1) do
-    %FunInfo{
-      args: [
-        [:atom_to_scope, :preload_scope]
-      ]
-    }
-  end
-
-  @moduledx_ args: %{first: [:atom_to_scope, :preload_scope], last: :final_args_fn}
+  @moduledx_ args: %{0 => [:atom_to_scope, :preload_scope], -1 => :final_args_fn}
 
   defscope all?(enumerable, fun, _generate_fallback) do
     quote do: {:not, {:any?, {:filter, unquote(enumerable), {:not, unquote(fun)}}}}

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Dx.MixProject do
         Basics: Path.wildcard("docs/basics/*.md")
       ],
       groups_for_modules: [
-        Extending: [Dx.Defd.Ext, Dx.Defd.Fn, Dx.Defd.Result, Dx.Evaluation, Dx.Scope]
+        Extending: [Dx.Defd_, Dx.Defd.Fn, Dx.Defd.Result, Dx.Evaluation, Dx.Scope]
       ],
       source_url: @source_url,
       source_ref: "v#{version()}"

--- a/test/dx/defd/ext_test.exs
+++ b/test/dx/defd/ext_test.exs
@@ -1,8 +1,0 @@
-defmodule Dx.Defd.ExtTest do
-  use ExUnit.Case, async: true
-
-  alias Dx.Defd.Ext.ArgInfo
-  alias Dx.Defd.Ext.FunInfo
-
-  doctest FunInfo, import: true
-end

--- a/test/dx/defd__test.exs
+++ b/test/dx/defd__test.exs
@@ -1,0 +1,8 @@
+defmodule Dx.Defd_Test do
+  use ExUnit.Case, async: true
+
+  alias Dx.Defd_.ArgInfo
+  alias Dx.Defd_.FunInfo
+
+  doctest FunInfo, import: true
+end

--- a/test/dx/defd__test.exs
+++ b/test/dx/defd__test.exs
@@ -5,4 +5,137 @@ defmodule Dx.Defd_Test do
   alias Dx.Defd_.FunInfo
 
   doctest FunInfo, import: true
+
+  describe "__dx_fun_info/2 callback" do
+    import Dx.Defd.Util, only: [fun_info: 3]
+
+    test "returns plain FunInfo by default" do
+      defmodule PlainTest do
+        use Dx.Defd_
+
+        defd_ bool_constant() do
+          {:ok, true}
+        end
+      end
+
+      assert %FunInfo{args: []} = fun_info(PlainTest, :bool_constant, 0)
+    end
+
+    test "with multiple arguments and different configurations" do
+      defmodule MultiArgsTest do
+        use Dx.Defd_
+
+        @dx_ args: %{0 => :preload_scope, 1 => :fn, 2 => [:preload_scope, :fn]}
+        defd_ process(data, _transformer, _callback) do
+          {:ok, data}
+        end
+      end
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: true},
+                 %ArgInfo{preload_scope: false, fn: %FunInfo{}},
+                 %ArgInfo{preload_scope: true, fn: %FunInfo{}}
+               ]
+             } = fun_info(MultiArgsTest, :process, 3)
+    end
+
+    test "@dx_ overrides @moduledx_" do
+      defmodule OverrideTest do
+        use Dx.Defd_
+
+        @moduledx_ args: %{all: :preload_scope}
+
+        @dx_ args: %{1 => :fn}
+        defd_ transform(input, _mapper) do
+          {:ok, input}
+        end
+      end
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: false},
+                 %ArgInfo{preload_scope: false, fn: %FunInfo{}}
+               ]
+             } = fun_info(OverrideTest, :transform, 2)
+    end
+
+    test "with nested function arguments" do
+      defmodule NestedFunTest do
+        use Dx.Defd_
+
+        @dx_ args: %{
+               0 => :preload_scope,
+               1 => {:fn, args: %{0 => :preload_scope}, arity: 1},
+               2 => {:fn, args: %{all: :fn}, arity: 1}
+             }
+        defd_ nested(data, _mapper, _reducer) do
+          {:ok, data}
+        end
+      end
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: true},
+                 %ArgInfo{
+                   preload_scope: false,
+                   fn: %FunInfo{
+                     args: [%ArgInfo{preload_scope: true}]
+                   }
+                 },
+                 %ArgInfo{
+                   preload_scope: false,
+                   fn: %FunInfo{
+                     args: [%ArgInfo{fn: %FunInfo{}}]
+                   }
+                 }
+               ]
+             } = fun_info(NestedFunTest, :nested, 3)
+    end
+
+    test "returns @moduledx_ if defined" do
+      defmodule Moduledx_Test do
+        use Dx.Defd_
+
+        @moduledx_ args: %{all: :preload_scope}
+
+        defd_ run(enum) do
+          Dx.Enum.map(enum, & &1)
+        end
+      end
+
+      assert %FunInfo{args: [%ArgInfo{preload_scope: true}]} =
+               fun_info(Moduledx_Test, :run, 1)
+    end
+
+    test "with default args" do
+      defmodule DefaultArgsTest do
+        use Dx.Defd_
+
+        @moduledx_ args: %{all: :preload_scope}
+
+        @dx_ args: %{0 => :preload_scope, 1 => :fn}
+        defd_ run(enum, mapper \\ nil) do
+          if mapper do
+            Dx.Enum.map(enum, mapper)
+          else
+            {:ok, enum}
+          end
+        end
+      end
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: true}
+               ]
+             } = fun_info(DefaultArgsTest, :run, 1)
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: true},
+                 %ArgInfo{fn: %FunInfo{}, preload_scope: false}
+               ]
+             } = fun_info(DefaultArgsTest, :run, 2)
+    end
+  end
 end

--- a/test/dx/defd__test.exs
+++ b/test/dx/defd__test.exs
@@ -60,6 +60,24 @@ defmodule Dx.Defd_Test do
              } = fun_info(OverrideTest, :transform, 2)
     end
 
+    test "non-negative index overrides negative index" do
+      defmodule OverrideNegativeTest do
+        use Dx.Defd_
+
+        @dx_ args: %{1 => %{preload_scope: false}, -1 => :preload_scope}
+        defd_ transform(input, _mapper) do
+          {:ok, input}
+        end
+      end
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: false},
+                 %ArgInfo{preload_scope: false}
+               ]
+             } = fun_info(OverrideNegativeTest, :transform, 2)
+    end
+
     test "with nested function arguments" do
       defmodule NestedFunTest do
         use Dx.Defd_

--- a/test/dx/defd__test.exs
+++ b/test/dx/defd__test.exs
@@ -108,11 +108,9 @@ defmodule Dx.Defd_Test do
                fun_info(Moduledx_Test, :run, 1)
     end
 
-    test "with default args" do
+    test "infers lower arity fun info for default args" do
       defmodule DefaultArgsTest do
         use Dx.Defd_
-
-        @moduledx_ args: %{all: :preload_scope}
 
         @dx_ args: %{0 => :preload_scope, 1 => :fn}
         defd_ run(enum, mapper \\ nil) do
@@ -126,16 +124,16 @@ defmodule Dx.Defd_Test do
 
       assert %FunInfo{
                args: [
-                 %ArgInfo{preload_scope: true}
-               ]
-             } = fun_info(DefaultArgsTest, :run, 1)
-
-      assert %FunInfo{
-               args: [
                  %ArgInfo{preload_scope: true},
                  %ArgInfo{fn: %FunInfo{}, preload_scope: false}
                ]
              } = fun_info(DefaultArgsTest, :run, 2)
+
+      assert %FunInfo{
+               args: [
+                 %ArgInfo{preload_scope: true}
+               ]
+             } = fun_info(DefaultArgsTest, :run, 1)
     end
   end
 end


### PR DESCRIPTION
This changes the API for making existing modules (e.g. the standard library) compatible with Dx.

All functions that take functions as arguments must be implemented natively, i.e. not via `defd` but via explicit handling of Dx-internal return types, usually `{:ok, ...}` or `{:not_loaded}`.

To aid with the implementation, the Dx compiler provides an API to pre-process the arguments before they're passed to the functions, e.g. loading any scopes (used to lazily translate Elixir code to SQL). See the [extension API docs](https://elixir-dx.github.io/dx/Dx.Defd.Ext.html) for more info. The compiler can skip any unneeded functions, and perform other optimizations.

This API is currently defined via a callback function, `__fun_info(fun_name, arity)`.

This PR introduces annotations that are co-located with the function definitions, instead of defining all callback clauses at the top of the module, and implementing the functions further below. See the changed in `Dx.Enum` in this PR for an example.

To pick up the annotations, `def` must be changed to `defd_`, standing for "native defd". The only difference currently being that it supports the annotations.

## Further options

These options are non-exclusive:

### Allow annotations for `def` (removing `defd_`)

This would make it more intuitive, as it's in line with libraries such as [decorator](https://hex.pm/packages/decorator).

On the other hand, keeping `defd_` could be used to define modules with a mix of `defd`, `defd_` and `def` (not compatible with defd) functions.

### Rename the callback & annotations to `__dx_compile__` and `@dx_compile`

This would make it clearer that it's an interface for instructions to the Dx compiler.